### PR TITLE
Consume add event endpoint #152801921

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["react", "env"]
+  "presets": ["react", "env"],
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
     "env": {
       "node": true,
       "es6": true,
-      "mocha": true
+      "mocha": true,
+      "browser": true
     },
     "rules": {
       "react/jsx-filename-extension": [1, {
@@ -41,7 +42,7 @@
         "requireParamDescription": false,
         "requireReturnDescription": true
       }],
-      "require-jsdoc": ["error", {
+      "require-jsdoc": [0, {
           "require": {
               "FunctionDeclaration": true,
               "MethodDefinition": true,

--- a/client/actions/actionCreators.js
+++ b/client/actions/actionCreators.js
@@ -1,4 +1,5 @@
 export const SIGN_IN_FAILED = 'SIGN_IN_FAILED';
+export const ADD_EVENT = 'ADD_EVENT';
 
 /**
  * formats the request from the user and returns it
@@ -41,5 +42,12 @@ export const addCenter = payload => {
   return {
     type: 'ADD_CENTER',
     payload
+  };
+};
+
+export const addEvent = event => {
+  return {
+    type: ADD_EVENT,
+    event
   };
 };

--- a/client/actions/actionCreators.js
+++ b/client/actions/actionCreators.js
@@ -1,5 +1,6 @@
+import * as actionTypes from './actionTypes';
+
 export const SIGN_IN_FAILED = 'SIGN_IN_FAILED';
-export const ADD_EVENT = 'ADD_EVENT';
 
 /**
  * formats the request from the user and returns it
@@ -47,7 +48,12 @@ export const addCenter = payload => {
 
 export const addEvent = event => {
   return {
-    type: ADD_EVENT,
+    type: actionTypes.ADD_EVENT,
     event
   };
 };
+
+// export const editEvent = event => ({
+//   type: actionTypes.EDIT_EVENT,
+//   event
+// });

--- a/client/actions/actionTypes.js
+++ b/client/actions/actionTypes.js
@@ -1,0 +1,5 @@
+export const ADD_EVENT_LOADING = 'ADD_EVENT_LOADING';
+export const ADD_EVENT = 'ADD_EVENT';
+export const ADD_EVENT_SUCCESS = 'ADD_EVENT_SUCCESS';
+export const ADD_EVENT_ERROR = 'ADD_EVENT_ERROR';
+

--- a/client/components/AddCenter.js
+++ b/client/components/AddCenter.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { Link, Redirect } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as actionCreators from '../actions/actionCreators';
-// import { addCenter } from '../actions/actionCreators';
+// import * as actionCreators from '../actions/actionCreators';
+import { addCenter } from '../actions/actionCreators';
 import Header from './Header';
 
 import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
@@ -74,13 +74,8 @@ class AddCenter extends React.Component {
       [e.target.name]: e.target.value
     });
     // console.log(this.state)
-  }// handleSubmit
+  }
 
-  // // tied to 'click me' button temporarily
-  // handleClick(e) {
-  //   e.preventDefault();
-  //   console.log(this.props.addCenter(this.state));
-  // }
 /**
  * renders signUpForm component
  * @returns {undefined} rendered component
@@ -127,8 +122,7 @@ render() {
  */
 const mapStateToProps = (state) => {
   return {
-    // addCenter: state.addCenter,
-    centers: state.center
+    //centers: state.center
   };
 }
 
@@ -136,15 +130,14 @@ const mapStateToProps = (state) => {
  * @param {any} dispatch 
  * @returns {object} actions
  */
-// const mapDispatchToProps = (dispatch) => {
-//   // return bindActionCreators(actionCreators, dispatch);
-//   return {
-//     addCenter: () => dispatch(addCenter())
-//   }
-// }
-
-const mapDispatchToProps = dispatch => {
-  return bindActionCreators(actionCreators, dispatch);
+const mapDispatchToProps = (dispatch) => {
+  return {
+    addCenter: (payload) => dispatch(addCenter(payload))
+  }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(AddCenter);
+// const mapDispatchToProps = dispatch => {
+//   return bindActionCreators(actionCreators, dispatch);
+// }
+
+export default connect(null, mapDispatchToProps)(AddCenter);

--- a/client/components/AddEvent.js
+++ b/client/components/AddEvent.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-
+import { connect } from 'react-redux';
+// import * as actionCreators from '../actions/actionCreators';
+import { addEvent } from '../actions/actionCreators';
 import Header from './Header';
 import "../../template/stylesheet/events.css";
 
@@ -14,8 +16,8 @@ class AddEvent extends Component {
     // console.log(props);
 
     this.state = {
-      name: '',
-      description: '',
+      title: '',
+      notes: '',
       center: '',
       date: ''
     }
@@ -24,17 +26,27 @@ class AddEvent extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
+  componentDidMount() {
+    console.log('mounted====> ', this.state);
+  }
+
   handleChange(e) {
     this.setState({
       [e.target.name]: e.target.value
     });
-    console.log(this.state);
+    // console.log(this.state);
   }
 
   handleSubmit(e) {
     e.preventDefault();
-    alert('event handler');
+    this.props.addEvent(this.state);
     // something should happen here - dispatch an action on submit
+    this.setState({
+      title: '',
+      notes: '',
+      center: '',
+      date: ''
+    });
   }
 
   render() {
@@ -47,21 +59,22 @@ class AddEvent extends Component {
                   <h2 className="text-center">Create An Event!</h2>
                   <div className="form-group">
                       <label htmlFor="event-name">Event Name:</label>
-                      <input className="form-control" type="text" name="name" id="event-name" placeholder="E.g. John's convocation" value={this.state.name} onChange={this.handleChange} />                  
+                      <input className="form-control" type="text" name="title" id="event-name" placeholder="E.g. John's convocation" value={this.state.title} onChange={this.handleChange} />                  
                   </div>
                   <div>
-                    <label htmlFor="">Optional Note:</label>
-                    <textarea className="form-control" name="description" id="description" cols="50" rows="4" placeholder="Enter an optional note"  value={this.state.description} onChange={this.handleChange}></textarea>
+                    <label htmlFor="notes">Optional Note:</label>
+                    <textarea className="form-control" name="notes" id="notes" cols="50" rows="4" placeholder="Enter an optional note"  value={this.state.notes} onChange={this.handleChange}></textarea>
                   </div>
                   <br />
                   <div className="form-group">
-                    <label htmlFor="">Event Center: </label>
+                    <label htmlFor="center">Event Center: </label>
                     <select className="form-control" name="center" id="center" value={this.state.center} onChange={this.handleChange}>
-                      <option value="rubyhall" title="Victoria Island Lagos">Ruby Hall</option>
-                      <option value="emeraldhall" title="Banana Island">Emerald hall</option>
-                      <option value="sapphore" title="Ketu">Sapphire</option>
-                      <option value="gold" title="Ikoyi">Gold</option>
-                      <option value="silver" title="Oluyole, Ibadan">Silver hall</option>
+                      <option value="1" title="Oluyole, Ibadan">First hall</option>
+                      <option value="2" title="Banana Island">Emerald hall</option>
+                      <option value="3" title="Ketu">Sapphire</option>
+                      <option value="4" title="Ikoyi">Gold</option>
+                      <option value="5" title="Oluyole, Ibadan">Silver hall</option>
+                      <option value="6" title="Victoria Island Lagos">Ruby Hall</option>
                     </select>
                   </div>
                   <div className="form-group">
@@ -96,4 +109,12 @@ class AddEvent extends Component {
   }
 }
 
-export default AddEvent;
+// const mapStateToProps = (state) => 
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    addEvent: (event) => dispatch(addEvent(event))
+  }
+}
+
+export default connect(null, mapDispatchToProps)(AddEvent);;

--- a/client/components/AddEvent.js
+++ b/client/components/AddEvent.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+
+import Header from './Header';
+import "../../template/stylesheet/events.css";
+
+/**
+ * Creates AddEvent Component
+ */
+class AddEvent extends Component {
+
+  constructor(props) {
+    super(props);
+    // console.log(props);
+
+    this.state = {
+      name: '',
+      description: '',
+      center: '',
+      date: ''
+    }
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleChange(e) {
+    this.setState({
+      [e.target.name]: e.target.value
+    });
+    console.log(this.state);
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    alert('event handler');
+    // something should happen here - dispatch an action on submit
+  }
+
+  render() {
+    return (
+      <div id="form">
+        <div className="container">
+          <div className="row fill-viewport">
+            <div className="col col-md-8">
+                <form id="form-box" action="" method="post" onSubmit={this.handleSubmit}>
+                  <h2 className="text-center">Create An Event!</h2>
+                  <div className="form-group">
+                      <label htmlFor="event-name">Event Name:</label>
+                      <input className="form-control" type="text" name="name" id="event-name" placeholder="E.g. John's convocation" value={this.state.name} onChange={this.handleChange} />                  
+                  </div>
+                  <div>
+                    <label htmlFor="">Optional Note:</label>
+                    <textarea className="form-control" name="description" id="description" cols="50" rows="4" placeholder="Enter an optional note"  value={this.state.description} onChange={this.handleChange}></textarea>
+                  </div>
+                  <br />
+                  <div className="form-group">
+                    <label htmlFor="">Event Center: </label>
+                    <select className="form-control" name="center" id="center" value={this.state.center} onChange={this.handleChange}>
+                      <option value="rubyhall" title="Victoria Island Lagos">Ruby Hall</option>
+                      <option value="emeraldhall" title="Banana Island">Emerald hall</option>
+                      <option value="sapphore" title="Ketu">Sapphire</option>
+                      <option value="gold" title="Ikoyi">Gold</option>
+                      <option value="silver" title="Oluyole, Ibadan">Silver hall</option>
+                    </select>
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="date">Choose a date and time:<br />MM/DD/YYYY</label>
+                    <input className="form-control" type="date" name="date" id="date" value={this.state.date} onChange={this.handleChange}/>
+                  </div>
+                  
+                  <input className="btn btn-outline-success" type="submit" value="Schedule"/>
+                </form>
+            </div>
+            <div className="col-md-4 text-center">
+              <h2>Event History</h2>
+              <div className="card">
+                <div className="card-body">
+                  <h4 className="card-title">Jane's Aniversaary</h4>
+                  <p className="card-text">Some example text. Some example text.</p>
+                  <a to="#" className="btn card-link"><i className="fa fa-edit fa-lg fw"></i> Update</a>
+                </div>
+              </div>
+              <div className="card">
+                <div className="card-body">
+                  <h4 className="card-title">Ade's Wedding</h4>
+                  <p className="card-text">Some example text. Some example text.</p>
+                  <a to="#" className="btn btn-dark card-link"><i className="fa fa-edit fa-lg fw"></i> Update</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  );
+  }
+}
+
+export default AddEvent;

--- a/client/components/Error.js
+++ b/client/components/Error.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Footer = () => {
+    return (
+      <div>
+        <h1>ERROR!!!</h1>
+      </div>
+    );
+};
+
+export default Footer;

--- a/client/reducers/eventsReducer.js
+++ b/client/reducers/eventsReducer.js
@@ -1,0 +1,22 @@
+import initialState from './initialState';
+import * as actionTypes from '../actions/actionTypes';
+
+const eventsReducer = (state=initialState.events, action) => {
+  switch (action.type) {
+
+    case actionTypes.ADD_EVENT_LOADING:
+      return {...state, addingEvent: true};
+
+    case actionTypes.ADD_EVENT_SUCCESS:
+      console.log('redcucer success===> ', {...state, addingEvent:false})
+      return {...state, addingEvent: false};
+
+    case actionTypes.ADD_EVENT_ERROR:
+      return {...state, error: action.error, addingEvent: false};
+      
+    default:
+      return state;
+  }
+}
+
+export default eventsReducer;

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -4,7 +4,14 @@ import { routerReducer } from 'react-router-redux';
 import signUp from './userSignUpReducer';
 import signIn from './signinReducer';
 import centers from './centersReducer';
+import events from './eventsReducer';
 
-const rootReducer = combineReducers({ signUp, signIn, centers, routing:routerReducer });
+const rootReducer = combineReducers({
+  signUp,
+  signIn,
+  centers,
+  events,
+  routing: routerReducer
+});
 
 export default rootReducer;

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -1,0 +1,10 @@
+/** 
+ * Inital state tree of the redux store
+ */
+export default {
+  events: {
+    addingEvent: false,
+    events: []
+  },
+  centers: []
+}

--- a/client/routes.js
+++ b/client/routes.js
@@ -7,6 +7,7 @@ import SignIn from '../client/components/SignIn';
 import SignUp from '../client/components/signUp';
 import Centers from '../client/components/Centers';
 import AddCenter from '../client/components/AddCenter';
+import AddEvent from '../client/components/AddEvent'
 
 export const history = createBrowserHistory();
 
@@ -18,6 +19,7 @@ export const Routes = () => {
         <Route exact path='/signup' component={SignUp}/>
         <Route exact path='/centers' component={Centers}/>
         <Route exact path='/addcenter' component={AddCenter}/>
+        <Route exact path='/addevent' component={AddEvent}/>
       </Switch>
   )
 }

--- a/client/routes.js
+++ b/client/routes.js
@@ -8,6 +8,7 @@ import SignUp from '../client/components/signUp';
 import Centers from '../client/components/Centers';
 import AddCenter from '../client/components/AddCenter';
 import AddEvent from '../client/components/AddEvent'
+import Error from '../client/components/Error'
 
 export const history = createBrowserHistory();
 
@@ -20,6 +21,7 @@ export const Routes = () => {
         <Route exact path='/centers' component={Centers}/>
         <Route exact path='/addcenter' component={AddCenter}/>
         <Route exact path='/addevent' component={AddEvent}/>
+        <Route exact path='/error' component={Error}/>
       </Switch>
   )
 }


### PR DESCRIPTION
#### What does this PR do?
Consumes `add event` endpoint with react/redux

#### Description
- rendering of components(form) that allows user to add an event
- state management with redux
- asynchronous operations with redux-saga

#### How should this be manually tested?
Clone the repo
Run `npm start:client` and `npm run start:server` in two different terminals
Navigate to `localhost:8080/addevent`

#### What are the relevant pivotal tracker stories?
152801921 
  